### PR TITLE
fix: add_apps variable type

### DIFF
--- a/argo/argocd-apps/variables.tf
+++ b/argo/argocd-apps/variables.tf
@@ -66,7 +66,7 @@ variable "install_apps" {
 }
 variable "add_apps" {
   default     = {}
-  type        = map(any)
+  type        = any
   description = "(Optional) Add new applications that are present in the enabled list."
 }
 variable "aws_route53_zone_arns" {


### PR DESCRIPTION
# Terraform Modules - Pull Request Review

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe the request

`Error: Invalid value for input variable` 

## Describe your changes

N/A

## Issue ticket number and link

N/A
